### PR TITLE
Update files to make PWA more specific to project

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Color Comparator</title>
     <link rel="stylesheet" href="styles.css">
-    <link rel="manifest" href="manifest.json">
+    <link rel="canonical" href="https://bgag2783.github.io/ColorSite/">
+    <link rel="manifest" href="/ColorSite/manifest.webmanifest">
 </head>
 <body>
     <div class="container">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -2,7 +2,10 @@
   "short_name": "Color Comparator",
   "name": "Color Comparator PWA",
   "description": "A simple PWA to compare two colors.",
-  "start_url": "/",
+
+  "scope":"/ColorSite/",
+  "start_url": "/ColorSite/",
+  
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#000000",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const cacheName = 'color-comparator-v1';
+const cacheName = 'color-comparator-v2';
 const assetsToCache = [
     '/',
     '/index.html',


### PR DESCRIPTION
I'm guessing that the PWA was defaulting to the main Github Pages site because the scope and start_url in the manifest were not specific enough. Also, I've updated the manifest to use the .webmanifest extension to match convention. 